### PR TITLE
Fix `Amm` to `AMM` and update README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Generate a definitions.json for ripple-binary-codec from a rippled source folder
 
 ## Usage
 ```
-node gen.js /your/path/to/rippled/src/ripple/ >> definitions.json
+node gen.js /your/path/to/rippled/src/ripple/ > definitions.json
 ```
 
 ## Example Output

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Generate a definitions.json for ripple-binary-codec from a rippled source folder
 
 ## Usage
 ```
-node gen.js /your/path/to/rippled/src/ripple/
+node gen.js /your/path/to/rippled/src/ripple/ >> definitions.json
 ```
 
 ## Example Output

--- a/gen.js
+++ b/gen.js
@@ -49,7 +49,9 @@ const translate = (inp)=>{
             let parts = inp.split('_');
             inp = '';
             for (x in parts)
-                if (parts[x] == 'NFTOKEN')
+                if (parts[x] == 'AMM')
+                    inp += parts[x].substr(0,3).toUpperCase();
+                else if (parts[x] == 'NFTOKEN')
                     inp += parts[x].substr(0,3).toUpperCase() + parts[x].substr(3).toLowerCase();
                 else
                     inp += parts[x].substr(0,1).toUpperCase() + parts[x].substr(1).toLowerCase();

--- a/gen.js
+++ b/gen.js
@@ -267,6 +267,8 @@ const ttranslate = (inp)=>{
             {
                 if (parts[x] == 'UNL')
                     inp += parts[x]
+                else if (parts[x] == 'AMM')
+                    inp += parts[x].substr(0,3).toUpperCase();
                 else if (parts[x] == 'NFTOKEN')
                     inp += parts[x].substr(0,3).toUpperCase() + parts[x].substr(3).toLowerCase();
                 else


### PR DESCRIPTION
Fix `Amm` to `AMM`.
Update README command to output to a definitions.json so it's easy to copy the contents of the output versus doing it in a terminal.