### PR TITLE
handle case to fix Amm to be AMM in LEDGER_ENTRY_TYPES

### DIFF
--- a/gen.js
+++ b/gen.js
@@ -37,6 +37,8 @@ const translate = (inp)=>{
                 return inp.replace("UINT", "UInt");
         if (inp == 'OBJECT' || inp == 'ARRAY')
             return 'ST' + inp.substr(0,1).toUpperCase() + inp.substr(1).toLowerCase();
+        if (inp == 'AMM')
+            return inp;
         if (inp == 'ACCOUNT')
             return 'AccountID';
         if (inp == 'LEDGERENTRY')


### PR DESCRIPTION
It doesn't handle the case for when a ledger entry type should remain the same and not be converted to UpperCamelCase in LEDGER_ENTRY_TYPES. For example, `AMM` is incorrectly being converted to `Amm`. I added logic to handle this case.